### PR TITLE
Add author entry to META

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
   "name" : "HTTP::Server",
   "version" : "0.1",
+  "author" : "github:tony-o",
   "description" : "role for HTTP::Server so we can have start building out some servers with interchangeable backends",
   "depends" : [],
   "provides" : {


### PR DESCRIPTION
Since HTTP::UserAgent defines classes with the same name as our roles
(HTTP::Request, HTTP::Response), adding this allows for
'use HTTP::Request:auth<github:tony-o>' to specify our role.
